### PR TITLE
Now using link wizard instead of group field to select pages

### DIFF
--- a/Configuration/TCA/tx_statictagcloud_domain_model_tag.php
+++ b/Configuration/TCA/tx_statictagcloud_domain_model_tag.php
@@ -138,17 +138,8 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:statictagcloud/Resources/Private/Language/locallang_db.xlf:tx_statictagcloud_domain_model_tag.link',
             'config' => [
-                'type' => 'group',
-                'internal_type' => 'db',
-                'allowed' => 'pages',
-                'minitems' => 1,
-                'maxitems' => 1,
-                'show_thumbs' => 0,
-                'wizards' => [
-                    'suggest' => [
-                        'type' => 'suggest'
-                    ]
-                ]
+                'type' => 'input',
+                'renderType' => 'inputLink'
             ]
         ],
         'priority' => [


### PR DESCRIPTION
I think the link wizard is better at this point because you have more possibilities e.g. external url, mail, etc.